### PR TITLE
feat: 공통 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "ox-note-for-yr",
 			"version": "0.1.0",
 			"dependencies": {
+				"@toss/use-overlay": "^1.4.0",
 				"firebase": "^10.10.0",
 				"next": "14.1.2",
 				"react": "^18",
@@ -2069,6 +2070,14 @@
 			"integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@toss/use-overlay": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@toss/use-overlay/-/use-overlay-1.4.0.tgz",
+			"integrity": "sha512-1fkKRwUWaPn1fPTHeYiOdnQu4j6sHLDfJZS1smsarPxWxUlr1+FikNIjzYQGAVXgNjxw0cqNfKR4HvVSsM5w3A==",
+			"peerDependencies": {
+				"react": "^16.8 || ^17 || ^18"
 			}
 		},
 		"node_modules/@types/babel__core": {
@@ -10215,6 +10224,12 @@
 			"requires": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"@toss/use-overlay": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@toss/use-overlay/-/use-overlay-1.4.0.tgz",
+			"integrity": "sha512-1fkKRwUWaPn1fPTHeYiOdnQu4j6sHLDfJZS1smsarPxWxUlr1+FikNIjzYQGAVXgNjxw0cqNfKR4HvVSsM5w3A==",
+			"requires": {}
 		},
 		"@types/babel__core": {
 			"version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"emulators:start": "firebase emulators:start --only hosting"
 	},
 	"dependencies": {
+		"@toss/use-overlay": "^1.4.0",
 		"firebase": "^10.10.0",
 		"next": "14.1.2",
 		"react": "^18",

--- a/src/app/category/hooks/useCategoryInput.ts
+++ b/src/app/category/hooks/useCategoryInput.ts
@@ -4,12 +4,14 @@ import { useState } from 'react';
 import { Category } from '../types';
 import { useCreateCategory } from '.';
 import { useConfirm } from '@/components';
+import { useToast } from '@/components/toast';
 
 export const useCategoryInput = (categoryList: Category[]) => {
 	const [categoryInput, setCategoryInput] = useState('');
 	const { createCategory } = useCreateCategory();
 
 	const confirm = useConfirm();
+	const addToast = useToast();
 
 	const inputChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (
 		event
@@ -27,18 +29,19 @@ export const useCategoryInput = (categoryList: Category[]) => {
 			message: `${categoryInput}으로 입력하면 변경이 불가능합니다. 추가하시겠습니까?`,
 		});
 
-		if (result) {
-			if (categoryList.map((c) => c.name).includes(categoryInput)) {
-				alert(`${categoryInput}은 중복되는 카테고리입니다`);
+		if (!result) return;
 
-				return;
-			}
-			createCategory({
-				id: `${Date.now()}`,
-				name: categoryInput,
-			});
-			setCategoryInput('');
+		if (categoryList.map((c) => c.name).includes(categoryInput)) {
+			addToast({ message: `중복되는 카테고리입니다` });
+			return;
 		}
+
+		createCategory({
+			id: `${Date.now()}`,
+			name: categoryInput,
+		});
+
+		setCategoryInput('');
 	};
 
 	return { categoryInput, inputChangeHandler, addCategoryHandler };

--- a/src/app/category/hooks/useCategoryInput.ts
+++ b/src/app/category/hooks/useCategoryInput.ts
@@ -3,10 +3,13 @@
 import { useState } from 'react';
 import { Category } from '../types';
 import { useCreateCategory } from '.';
+import { useConfirm } from '@/components';
 
 export const useCategoryInput = (categoryList: Category[]) => {
 	const [categoryInput, setCategoryInput] = useState('');
 	const { createCategory } = useCreateCategory();
+
+	const confirm = useConfirm();
 
 	const inputChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (
 		event
@@ -19,9 +22,10 @@ export const useCategoryInput = (categoryList: Category[]) => {
 	) => {
 		event.preventDefault();
 
-		const result = confirm(
-			`${categoryInput}으로 입력하면 변경이 불가능합니다. 추가하시겠습니까?`
-		);
+		const result = await confirm({
+			title: '안내',
+			message: `${categoryInput}으로 입력하면 변경이 불가능합니다. 추가하시겠습니까?`,
+		});
 
 		if (result) {
 			if (categoryList.map((c) => c.name).includes(categoryInput)) {

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { URL_PATH } from '@/constants/path';
 import { SWRConfig } from 'swr';
 import { Spinner } from '@/components';
+import { OverlayProvider } from '@toss/use-overlay';
 
 const RootTemplate = ({ children }: { children: React.ReactNode }) => {
 	const router = useRouter();
@@ -36,7 +37,9 @@ const RootTemplate = ({ children }: { children: React.ReactNode }) => {
 				fallback: <Spinner />,
 			}}
 		>
-			<div className={styles.container}>{children}</div>;
+			<OverlayProvider>
+				<div className={styles.container}>{children}</div>
+			</OverlayProvider>
 		</SWRConfig>
 	);
 };

--- a/src/components/confirm/Confirm.tsx
+++ b/src/components/confirm/Confirm.tsx
@@ -3,15 +3,15 @@
 import { useState, useEffect } from 'react';
 import styles from './confirm.module.scss';
 import { Button } from '..';
+import { ConfirmProps } from './confirm.type';
 
-type Props = {
-	title?: string;
-	message: string;
-	onConfirm: () => void;
-	onClose: () => void;
-};
-
-const Confirm = ({ title, message, onConfirm, onClose }: Props) => {
+const Confirm = ({
+	title,
+	message,
+	onConfirm,
+	onClose,
+	onCancel,
+}: ConfirmProps) => {
 	const [visible, setVisible] = useState(false);
 
 	useEffect(() => {
@@ -26,6 +26,7 @@ const Confirm = ({ title, message, onConfirm, onClose }: Props) => {
 
 	const handleCancel = () => {
 		setVisible(false);
+		onCancel();
 		setTimeout(onClose, 200);
 	};
 

--- a/src/components/confirm/Confirm.tsx
+++ b/src/components/confirm/Confirm.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import styles from './confirm.module.scss';
+import { Button } from '..';
+
+type Props = {
+	title?: string;
+	message: string;
+	onConfirm: () => void;
+	onClose: () => void;
+};
+
+const Confirm = ({ title, message, onConfirm, onClose }: Props) => {
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		setVisible(true);
+	}, []);
+
+	const handleConfirm = () => {
+		setVisible(false);
+		onConfirm();
+		setTimeout(onClose, 200);
+	};
+
+	const handleCancel = () => {
+		setVisible(false);
+		setTimeout(onClose, 200);
+	};
+
+	return (
+		<div className={`${styles.overlay}`}>
+			<div
+				className={`${styles.confirm} ${visible ? styles.show : styles.hide}`}
+			>
+				{title && <p className={styles.title}>{title}</p>}
+				<p>{message}</p>
+				<div className={styles.buttons}>
+					<Button
+						size='medium'
+						className={`${styles['basic-button']}`}
+						onClick={handleCancel}
+					>
+						취소하기
+					</Button>
+					<Button
+						size='medium'
+						className={`${styles['basic-button']} ${styles['confirm-button']}`}
+						onClick={handleConfirm}
+					>
+						확인
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Confirm;

--- a/src/components/confirm/confirm.module.scss
+++ b/src/components/confirm/confirm.module.scss
@@ -1,0 +1,76 @@
+@import '@/styles/variables.module.scss';
+@import '@/styles/mixins.module.scss';
+
+.overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.5);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1040;
+}
+
+.confirm {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	background-color: #{$white};
+	padding: 20px;
+	border-radius: 5px;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+	transform: translateY(100px);
+	opacity: 0;
+	transition: opacity 0.5s ease, transform 0.5s ease;
+	text-align: center;
+	max-width: 400px;
+	width: 100%;
+	z-index: 1050;
+
+	font-size: 1.4rem;
+	line-height: 1.5;
+	font-weight: 400;
+}
+
+.title {
+	font-size: 1.8rem;
+	line-height: 1.5;
+	font-weight: 600;
+	text-align: left;
+}
+
+.buttons {
+	display: flex;
+	justify-content: space-between;
+	gap: 32px;
+}
+
+.confirm-button {
+	background: #{$correct};
+	color: #{$white};
+}
+
+.basic-button {
+	padding: 10px 20px;
+	border: none;
+	border-radius: 5px;
+	cursor: pointer;
+	transition: background-color 0.3s ease;
+}
+
+.basic-button:hover {
+	opacity: 0.9;
+}
+
+.show {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+.hide {
+	opacity: 0;
+	transform: translateY(100px);
+}

--- a/src/components/confirm/confirm.type.ts
+++ b/src/components/confirm/confirm.type.ts
@@ -1,0 +1,7 @@
+export type ConfirmProps = {
+	title?: string;
+	message: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+	onClose: () => void;
+};

--- a/src/components/confirm/hooks/useConfirm.tsx
+++ b/src/components/confirm/hooks/useConfirm.tsx
@@ -1,0 +1,35 @@
+import { useOverlay } from '@toss/use-overlay';
+import { useCallback, useMemo, useState } from 'react';
+import { Confirm } from '..';
+import { ConfirmProps } from '../confirm.type';
+
+const useConfirm = () => {
+	const overlay = useOverlay();
+	const [answer, setAnswer] = useState<boolean | null>(null);
+
+	const confirm = useCallback(
+		(params: Pick<ConfirmProps, 'message' | 'title'>) => {
+			const userAnswer = new Promise<boolean>((resolve) => {
+				const resolveAndClose = (userAnswer: boolean) => {
+					resolve(userAnswer);
+				};
+
+				overlay.open(({ exit }) => (
+					<Confirm
+						onClose={exit}
+						onCancel={() => resolveAndClose(false)}
+						onConfirm={() => resolveAndClose(true)}
+						{...params}
+					/>
+				));
+			});
+
+			return userAnswer;
+		},
+		[overlay]
+	);
+
+	return confirm;
+};
+
+export default useConfirm;

--- a/src/components/confirm/index.ts
+++ b/src/components/confirm/index.ts
@@ -1,0 +1,2 @@
+export { default as Confirm } from './Confirm';
+export { default as useConfirm } from './hooks/useConfirm';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,4 +11,4 @@ export { default as Selector } from '@/components/selector';
 export { default as Pagination } from '@/components/pagination/Pagination';
 export { default as QuizItem } from '@/components/quiz-list-item/QuizListItem';
 export { default as Toast } from '@/components/toast/Toast';
-export { default as Confirm } from '@/components/confirm/Confirm';
+export * from '@/components/confirm';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as Selector } from '@/components/selector';
 export { default as Pagination } from '@/components/pagination/Pagination';
 export { default as QuizItem } from '@/components/quiz-list-item/QuizListItem';
 export { default as Toast } from '@/components/toast/Toast';
+export { default as Confirm } from '@/components/confirm/Confirm';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,3 +10,4 @@ export { default as QuizForm } from '@/components/quiz-form/QuizForm';
 export { default as Selector } from '@/components/selector';
 export { default as Pagination } from '@/components/pagination/Pagination';
 export { default as QuizItem } from '@/components/quiz-list-item/QuizListItem';
+export { default as Toast } from '@/components/toast/Toast';

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -2,14 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import styles from './toast.module.scss';
+import { ToastProps } from './toast.type';
 
-type Props = {
-	message: string;
-	onClose: () => void;
-	duration?: number;
-};
-
-const Toast = ({ message, onClose, duration = 2000 }: Props) => {
+const Toast = ({ message, onClose, duration = 2000 }: ToastProps) => {
 	const [visible, setVisible] = useState(false);
 
 	useEffect(() => {

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import styles from './toast.module.scss';
+
+type Props = {
+	message: string;
+	onClose: () => void;
+	duration?: number;
+};
+
+const Toast = ({ message, onClose, duration = 2000 }: Props) => {
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		setVisible(true);
+		const timer = setTimeout(() => {
+			setVisible(false);
+			setTimeout(onClose, 500); // Wait for animation to complete
+		}, duration);
+
+		return () => {
+			clearTimeout(timer);
+		};
+	}, [duration, onClose]);
+
+	return (
+		<div className={`${styles.toast} ${visible ? styles.show : styles.hide} `}>
+			{message}
+		</div>
+	);
+};
+
+export default Toast;

--- a/src/components/toast/hooks/useToast.tsx
+++ b/src/components/toast/hooks/useToast.tsx
@@ -1,0 +1,19 @@
+import { useOverlay } from '@toss/use-overlay';
+import { useCallback } from 'react';
+
+import { Toast, ToastProps } from '..';
+
+const useToast = () => {
+	const overlay = useOverlay();
+
+	const addToast = useCallback(
+		(params: Omit<ToastProps, 'onClose'>) => {
+			overlay.open(({ exit }) => <Toast onClose={exit} {...params} />);
+		},
+		[overlay]
+	);
+
+	return addToast;
+};
+
+export default useToast;

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,0 +1,3 @@
+export { default as Toast } from './Toast';
+export { default as useToast } from './hooks/useToast';
+export * from './toast.type';

--- a/src/components/toast/toast.module.scss
+++ b/src/components/toast/toast.module.scss
@@ -1,0 +1,37 @@
+@import '@/styles/variables.module.scss';
+@import '@/styles/mixins.module.scss';
+
+.toast {
+	position: fixed;
+	left: 50%;
+	bottom: 80px;
+	transform: translateX(-50%);
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	max-width: 90%;
+	height: 40px;
+
+	background-color: #{$black-80};
+	color: #{white};
+	padding: 10px 20px;
+	border-radius: 5px;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+	opacity: 0.9;
+	z-index: 1030;
+	transition: opacity 0.5s ease, transform 0.5s ease;
+	font-size: 1.4rem;
+	line-height: 1.5;
+	font-weight: 400;
+}
+
+.toast.show {
+	opacity: 0.9;
+	transform: translateX(-50%) translateY(0);
+}
+
+.toast.hide {
+	opacity: 0;
+	transform: translateX(-50%) translateY(80px);
+}

--- a/src/components/toast/toast.type.ts
+++ b/src/components/toast/toast.type.ts
@@ -1,0 +1,5 @@
+export type ToastProps = {
+	message: string;
+	onClose: () => void;
+	duration?: number;
+};


### PR DESCRIPTION
- [x] `confirm` 컴포넌트 구현
- [x] `toast` 컴포넌트 구현

사용자에게 안내를 하기 위해 나름의 컴포넌트를 만들었습니다. 일반적인 알림을 줄 수 있는 toast 컴포넌트와 사용자의 응답을 받아서 처리하는 confirm 컴포넌트입니다.

여기서 따로 modal 등의 컴포넌트를 구현하지 않고, toass의 `useOverlay`라이브러리를 통해 선언적으로 컴포넌트를 구현했습니다