### PR TITLE
feat: 커스텀 에러 적용

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,23 @@ const nextConfig = {
 
 		return [];
 	},
+	async headers() {
+		return [
+			{
+				source: '/(.*)',
+				headers: [
+					{
+						key: 'Cross-Origin-Opener-Policy',
+						value: 'same-origin-allow-popups',
+					},
+					{
+						key: 'Cross-Origin-Resource-Policy',
+						value: 'cross-origin',
+					},
+				],
+			},
+		];
+	},
 };
 
 export default nextConfig;

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -17,66 +17,52 @@ type BodyParams = {
 export const POST = requestWrapper(
 	async (req) => {
 		const { arg } = (await req.json()) as { arg: BodyParams };
-		try {
-			const snapshot = await getDocumentSnapshot(
-				`${arg.uid}/user`,
-				userFireStoreConverter
-			);
 
-			if (!snapshot.exists()) {
-				await updateDocumentData({ path: `${arg.uid}/user`, data: arg });
-				await updateDocumentData({ path: `${arg.uid}/category`, data: {} });
-				await updateDocumentData({ path: `${arg.uid}/quiz`, data: {} });
+		const snapshot = await getDocumentSnapshot(
+			`${arg.uid}/user`,
+			userFireStoreConverter
+		);
 
-				return nextResponseWithResponseType({
-					body: {
-						message: RESPONSE_MESSAGE.SUCCESS,
-						code: HTTP_STATUS_CODE.CREATED,
-						data: null,
-						errors: null,
-					},
+		if (!snapshot.exists()) {
+			await updateDocumentData({ path: `${arg.uid}/user`, data: arg });
+			await updateDocumentData({ path: `${arg.uid}/category`, data: {} });
+			await updateDocumentData({ path: `${arg.uid}/quiz`, data: {} });
 
-					options: {
-						status: HTTP_STATUS_CODE.CREATED,
-					},
-				});
-			}
-
-			const successResponse = nextResponseWithResponseType({
+			return nextResponseWithResponseType({
 				body: {
 					message: RESPONSE_MESSAGE.SUCCESS,
-					code: HTTP_STATUS_CODE.OK,
+					code: HTTP_STATUS_CODE.CREATED,
 					data: null,
 					errors: null,
 				},
 
 				options: {
-					status: HTTP_STATUS_CODE.OK,
-				},
-			});
-
-			successResponse.cookies.set('user-id', arg.uid, {
-				path: '/',
-			});
-
-			return successResponse;
-		} catch (e) {
-			return nextResponseWithResponseType({
-				body: {
-					message: RESPONSE_MESSAGE.FAILURE,
-					code: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR,
-					data: null,
-					errors: {
-						code: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR,
-						message: `확인되지 않은 에러가 발생했습니다 : ${JSON.stringify(e)}`,
-					},
-				},
-
-				options: {
-					status: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR,
+					status: HTTP_STATUS_CODE.CREATED,
 				},
 			});
 		}
+
+		const successResponse = nextResponseWithResponseType({
+			body: {
+				message: RESPONSE_MESSAGE.SUCCESS,
+				code: HTTP_STATUS_CODE.OK,
+				data: null,
+				errors: null,
+			},
+
+			options: {
+				status: HTTP_STATUS_CODE.OK,
+			},
+		});
+
+		successResponse.cookies.set('user-id', arg.uid, {
+			path: '/',
+			expires: 60 * 60 * 24 * 14 * 1000,
+			httpOnly: true,
+			secure: false,
+		});
+
+		return successResponse;
 	},
 	{
 		methodWhiteList: [HTTP_METHOD.POST],

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,36 @@
+import { app } from '@/lib/firebase';
+import {
+	HTTP_METHOD,
+	HTTP_STATUS_CODE,
+	RESPONSE_MESSAGE,
+	nextResponseWithResponseType,
+	requestWrapper,
+} from '@/lib/request-wrapper';
+import { getAuth, signOut } from 'firebase/auth';
+
+export const POST = requestWrapper(
+	async () => {
+		const auth = getAuth(app);
+
+		const successResponse = nextResponseWithResponseType({
+			body: {
+				message: RESPONSE_MESSAGE.SUCCESS,
+				code: HTTP_STATUS_CODE.OK,
+				data: null,
+				errors: null,
+			},
+
+			options: {
+				status: HTTP_STATUS_CODE.OK,
+			},
+		});
+		await signOut(auth);
+
+		successResponse.cookies.delete('user-id');
+
+		return successResponse;
+	},
+	{
+		methodWhiteList: [HTTP_METHOD.POST],
+	}
+);

--- a/src/app/api/category/route.ts
+++ b/src/app/api/category/route.ts
@@ -19,59 +19,42 @@ type Category = {
 
 export const GET = requestWrapper(
 	async (req) => {
-		try {
-			const { cookies, url } = req;
+		const { cookies, url } = req;
 
-			const userId = cookies.get('user-id');
+		const userId = cookies.get('user-id');
 
-			const categorySnapshot = await getDocumentSnapshot(
-				`${userId?.value}/category`,
-				categoryFireStoreConverter
-			);
+		const categorySnapshot = await getDocumentSnapshot(
+			`${userId?.value}/category`,
+			categoryFireStoreConverter
+		);
 
-			if (!categorySnapshot.exists()) {
-				return nextResponseWithResponseType({
-					body: {
-						message: RESPONSE_MESSAGE.SUCCESS,
-						code: HTTP_STATUS_CODE.OK,
-						data: [],
-						errors: null,
-					},
-					options: {
-						status: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR,
-					},
-				});
-			}
-
-			const data = categorySnapshot.data();
-
+		if (!categorySnapshot.exists()) {
 			return nextResponseWithResponseType({
 				body: {
 					message: RESPONSE_MESSAGE.SUCCESS,
 					code: HTTP_STATUS_CODE.OK,
-					data: data,
+					data: [],
 					errors: null,
 				},
 				options: {
-					status: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR,
+					status: HTTP_STATUS_CODE.OK,
 				},
-			});
-		} catch (error) {
-			return nextResponseWithResponseType({
-				body: {
-					message: RESPONSE_MESSAGE.FAILURE,
-					code: null,
-					data: null,
-					errors: {
-						code: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR,
-						message: `확인되지 않은 에러가 발생했습니다 : ${JSON.stringify(
-							error
-						)}`,
-					},
-				},
-				options: { status: HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR },
 			});
 		}
+
+		const data = categorySnapshot.data();
+
+		return nextResponseWithResponseType({
+			body: {
+				message: RESPONSE_MESSAGE.SUCCESS,
+				code: HTTP_STATUS_CODE.OK,
+				data: data,
+				errors: null,
+			},
+			options: {
+				status: HTTP_STATUS_CODE.OK,
+			},
+		});
 	},
 	{
 		methodWhiteList: [HTTP_METHOD.GET],

--- a/src/app/auth/hooks/useLogin.ts
+++ b/src/app/auth/hooks/useLogin.ts
@@ -1,4 +1,5 @@
 import { http } from '@/lib/api';
+import { CustomError } from '@/lib/error';
 import { useCallback } from 'react';
 import { Key } from 'swr';
 import useSWRMutation, { SWRMutationConfiguration } from 'swr/mutation';
@@ -9,15 +10,18 @@ type BodyParams = {
 	userName: string | null;
 };
 
-type Params<D> = Pick<SWRMutationConfiguration<D, Error>, 'onSuccess'>;
+type Params<D> = Pick<
+	SWRMutationConfiguration<D, CustomError>,
+	'onSuccess' | 'onError'
+>;
 
-export const useLogin = ({ onSuccess }: Params<void> = {}) => {
+export const useLogin = ({ onSuccess, onError }: Params<void> = {}) => {
 	const { trigger, isMutating, reset } = useSWRMutation<
 		void,
-		Error,
+		CustomError,
 		Key,
 		BodyParams
-	>('/api/auth', http.post, { onSuccess });
+	>('/api/auth', http.post, { onSuccess, onError });
 
 	const login = useCallback(
 		async (params: BodyParams) => {

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -5,9 +5,12 @@ import { signInWithGoogle } from '@/lib/firebase';
 import { useRouter } from 'next/navigation';
 import { URL_PATH } from '@/constants/path';
 import { useLogin } from './hooks';
+import { useToast } from '@/components/toast';
+import { CustomError } from '@/lib/error';
 
 const Auth = () => {
 	const router = useRouter();
+	const addToast = useToast();
 	const { login } = useLogin({
 		onSuccess: () => router.push(URL_PATH.CATEGORY),
 	});
@@ -19,9 +22,15 @@ const Auth = () => {
 			const result = await signInWithGoogle();
 			const { uid, displayName, email } = result.user;
 
-			login({ uid, email, userName: displayName });
+			await login({ uid, email, userName: displayName });
 		} catch (e) {
-			console.error(e);
+			let message = '로그인하는데 실패했습니다. 다시 시도해주세요';
+			if (e instanceof CustomError) {
+				message = e.message;
+			}
+			addToast({
+				message,
+			});
 		}
 	};
 

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -12,7 +12,10 @@ const Auth = () => {
 	const router = useRouter();
 	const addToast = useToast();
 	const { login } = useLogin({
-		onSuccess: () => router.push(URL_PATH.CATEGORY),
+		onSuccess: () => {
+			router.replace(URL_PATH.CATEGORY);
+		},
+		onError: (err) => console.log(err),
 	});
 
 	const googleLoginHandler: React.MouseEventHandler<

--- a/src/app/category/components/CategoryInput.tsx
+++ b/src/app/category/components/CategoryInput.tsx
@@ -22,8 +22,9 @@ const CategoryInput = ({ category }: CategoryInputProps) => {
 				onChange={inputChangeHandler}
 			/>
 			<Button
-				size='large'
+				size='medium'
 				className={styles['add-button']}
+				color='primary'
 				type='button'
 				onClick={addCategoryHandler}
 			>

--- a/src/app/category/components/CategoryInput.tsx
+++ b/src/app/category/components/CategoryInput.tsx
@@ -24,7 +24,7 @@ const CategoryInput = ({ category }: CategoryInputProps) => {
 			<Button
 				size='large'
 				className={styles['add-button']}
-				type='submit'
+				type='button'
 				onClick={addCategoryHandler}
 			>
 				추가하기

--- a/src/app/category/components/categoryInput.module.scss
+++ b/src/app/category/components/categoryInput.module.scss
@@ -19,7 +19,5 @@
 	width: 35%;
 	padding: 8px;
 	border-radius: 8px;
-	background-color: #{$correct};
 	color: #{$white};
-	height: #{$button-height};
 }

--- a/src/app/category/hooks/useCreateCategory.ts
+++ b/src/app/category/hooks/useCreateCategory.ts
@@ -3,14 +3,22 @@ import { Category } from '../types';
 import { useCallback } from 'react';
 import useSWRMutation from 'swr/mutation';
 import { Key } from 'swr';
+import { CustomError } from '@/lib/error';
+import { useToast } from '@/components/toast';
 
 export const useCreateCategory = () => {
+	const addToast = useToast();
+
 	const { trigger, isMutating, reset } = useSWRMutation<
 		null,
-		Error,
+		CustomError,
 		Key,
 		Category
-	>('/api/category', http.post);
+	>('/api/category', http.post, {
+		onError: (err) => {
+			addToast({ message: err.message });
+		},
+	});
 
 	const createCategory = useCallback(
 		async (params: Category) => {

--- a/src/app/category/layout.tsx
+++ b/src/app/category/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
+import styles from './category.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -9,7 +10,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 			<Header>
 				<Header.Title title='카테고리' />
 			</Header>
-			{children}
+			<main className={styles.main}>{children}</main>
 		</Fragment>
 	);
 };

--- a/src/app/category/layout.tsx
+++ b/src/app/category/layout.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { Header, Navbar } from '@/components';
+import { Header } from '@/components';
 import { Fragment } from 'react';
-import styles from './category.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -10,8 +9,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 			<Header>
 				<Header.Title title='카테고리' />
 			</Header>
-			<main className={styles.main}>{children}</main>
-			<Navbar />
+			{children}
 		</Fragment>
 	);
 };

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { CustomError } from '@/lib/error';
+
+export default function GlobalError({
+	error,
+	reset,
+}: {
+	error: CustomError;
+	reset: () => void;
+}) {
+	return (
+		<html>
+			<body>
+				<h2>{error.message}</h2>
+				<button onClick={() => reset()}>다시 시도하기</button>
+			</body>
+		</html>
+	);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import '../styles/globals.scss';
+import styles from './root.module.scss';
+import Navbar from '@/components/navbar';
+
+// NOTE: import {}를 통해서 컴포넌트를 받지 말자
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -16,7 +20,12 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang='ko'>
-			<body className={inter.className}>{children}</body>
+			<body className={inter.className}>
+				<div className={styles.container}>
+					<main className={styles.main}>{children}</main>
+					<Navbar />
+				</div>
+			</body>
 		</html>
 	);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
 		<html lang='ko'>
 			<body className={inter.className}>
 				<div className={styles.container}>
-					<main className={styles.main}>{children}</main>
+					{children}
 					<Navbar />
 				</div>
 			</body>

--- a/src/app/my-page/hooks/index.ts
+++ b/src/app/my-page/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useAccountDelete';
+export * from './useLogout';

--- a/src/app/my-page/hooks/index.ts
+++ b/src/app/my-page/hooks/index.ts
@@ -1,2 +1,2 @@
-export * from './useAccountDelete';
+export * from './useDeleteAccount';
 export * from './useLogout';

--- a/src/app/my-page/hooks/useDeleteAccount.ts
+++ b/src/app/my-page/hooks/useDeleteAccount.ts
@@ -5,16 +5,23 @@ import { CustomError } from '@/lib/error';
 import { useToast } from '@/components/toast';
 import { useRouter } from 'next/navigation';
 import { URL_PATH } from '@/constants/path';
+import { deleteUser } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
 
-export const useLogout = () => {
+const { currentUser } = auth;
+
+export const useDeleteAccount = () => {
 	const addToast = useToast();
 	const router = useRouter();
 
 	const { trigger, isMutating, reset } = useSWRMutation<null, CustomError>(
-		'/api/auth/signout',
-		http.post,
+		'/api/auth',
+		http.delete,
 		{
-			onSuccess: () => {
+			onSuccess: async () => {
+				if (currentUser) {
+					await deleteUser(currentUser);
+				}
 				router.push(URL_PATH.AUTH);
 			},
 			onError: (err) => {
@@ -23,10 +30,10 @@ export const useLogout = () => {
 		}
 	);
 
-	const logout = useCallback(async () => {
+	const deleteAccount = useCallback(async () => {
 		const result = await trigger();
 		return result;
 	}, [trigger]);
 
-	return { logout, isMutating, reset };
+	return { deleteAccount, isMutating, reset };
 };

--- a/src/app/my-page/hooks/useLogout.ts
+++ b/src/app/my-page/hooks/useLogout.ts
@@ -1,0 +1,33 @@
+import { http } from '@/lib/api';
+import { useCallback } from 'react';
+import useSWRMutation from 'swr/mutation';
+import { Key } from 'swr';
+import { CustomError } from '@/lib/error';
+import { useToast } from '@/components/toast';
+import { useRouter } from 'next/navigation';
+import { URL_PATH } from '@/constants/path';
+
+export const useLogout = () => {
+	const addToast = useToast();
+	const router = useRouter();
+
+	const { trigger, isMutating, reset } = useSWRMutation<null, CustomError>(
+		'/api/auth/signout',
+		http.post,
+		{
+			onSuccess: () => {
+				router.push(URL_PATH.AUTH);
+			},
+			onError: (err) => {
+				addToast({ message: err.message });
+			},
+		}
+	);
+
+	const logout = useCallback(async () => {
+		const result = await trigger();
+		return result;
+	}, [trigger]);
+
+	return { logout, isMutating, reset };
+};

--- a/src/app/my-page/layout.tsx
+++ b/src/app/my-page/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
+import styles from './my-page.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -9,7 +10,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 			<Header>
 				<Header.Title title='마이페이지' />
 			</Header>
-			{children}
+			<main className={styles.main}>{children}</main>
 		</Fragment>
 	);
 };

--- a/src/app/my-page/layout.tsx
+++ b/src/app/my-page/layout.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { Header, Navbar } from '@/components';
+import { Header } from '@/components';
 import { Fragment } from 'react';
-import styles from './my-page.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -10,8 +9,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 			<Header>
 				<Header.Title title='마이페이지' />
 			</Header>
-			<main className={styles.main}>{children}</main>
-			<Navbar />
+			{children}
 		</Fragment>
 	);
 };

--- a/src/app/my-page/my-page.module.scss
+++ b/src/app/my-page/my-page.module.scss
@@ -1,3 +1,10 @@
 @import '@/styles/variables.module.scss';
 @import '@/styles/mixins.module.scss';
 @import '../root.module.scss';
+
+.wrapper {
+	display: flex;
+
+	width: 100%;
+	justify-content: space-around;
+}

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,20 +1,13 @@
 'use client';
 
-import { useToast } from '@/components/toast';
-import { getAuth, signOut } from 'firebase/auth';
 import { MouseEventHandler } from 'react';
+import { useLogout } from './hooks/useLogout';
 
 const MyPage = () => {
-	const addToast = useToast();
+	const { logout } = useLogout();
 
-	const logoutHandler: MouseEventHandler<HTMLButtonElement> = async () => {
-		const auth = getAuth();
-		try {
-			await signOut(auth);
-		} catch (error) {
-			addToast({ message: '로그아웃에 실패했습니다' });
-		}
-	};
+	const logoutHandler: MouseEventHandler<HTMLButtonElement> = () => logout();
+
 	return (
 		<section>
 			<div>

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,8 +1,27 @@
+'use client';
+
+import { useToast } from '@/components/toast';
+import { getAuth, signOut } from 'firebase/auth';
+import { MouseEventHandler } from 'react';
+
 const MyPage = () => {
+	const addToast = useToast();
+
+	const logoutHandler: MouseEventHandler<HTMLButtonElement> = async () => {
+		const auth = getAuth();
+		try {
+			await signOut(auth);
+			console.log('User logged out successfully');
+		} catch (error) {
+			addToast({ message: '로그아웃에 실패했습니다' });
+		}
+	};
 	return (
 		<section>
 			<div>
-				<button>로그아웃</button>
+				<button onClick={logoutHandler} type='button'>
+					로그아웃
+				</button>
 				<button>회월 탈퇴</button>
 			</div>
 		</section>

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -2,19 +2,37 @@
 
 import { MouseEventHandler } from 'react';
 import { useLogout } from './hooks/useLogout';
+import { useDeleteAccount } from './hooks';
+import { Button, useConfirm } from '@/components';
 
 const MyPage = () => {
 	const { logout } = useLogout();
+	const { deleteAccount } = useDeleteAccount();
+	const confirm = useConfirm();
 
 	const logoutHandler: MouseEventHandler<HTMLButtonElement> = () => logout();
+	const deleteAccountHandler: MouseEventHandler<
+		HTMLButtonElement
+	> = async () => {
+		const result = await confirm({
+			message:
+				'계정을 삭제하시면 작성한 데이터가 모두 없어집니다. 삭제하시겠습니까?',
+		});
+
+		if (result) {
+			deleteAccount();
+		}
+	};
 
 	return (
 		<section>
 			<div>
-				<button onClick={logoutHandler} type='button'>
+				<Button onClick={logoutHandler} type='button'>
 					로그아웃
-				</button>
-				<button>회월 탈퇴</button>
+				</Button>
+				<Button onClick={deleteAccountHandler} type='button' disabled>
+					회월 탈퇴
+				</Button>
 			</div>
 		</section>
 	);

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -4,6 +4,7 @@ import { MouseEventHandler } from 'react';
 import { useLogout } from './hooks/useLogout';
 import { useDeleteAccount } from './hooks';
 import { Button, useConfirm } from '@/components';
+import styles from './my-page.module.scss';
 
 const MyPage = () => {
 	const { logout } = useLogout();
@@ -26,11 +27,21 @@ const MyPage = () => {
 
 	return (
 		<section>
-			<div>
-				<Button onClick={logoutHandler} type='button'>
+			<div className={styles.wrapper}>
+				<Button
+					onClick={logoutHandler}
+					size='medium'
+					color='default'
+					type='button'
+				>
 					로그아웃
 				</Button>
-				<Button onClick={deleteAccountHandler} type='button' disabled>
+				<Button
+					onClick={deleteAccountHandler}
+					size='medium'
+					type='button'
+					disabled
+				>
 					회월 탈퇴
 				</Button>
 			</div>

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -11,7 +11,6 @@ const MyPage = () => {
 		const auth = getAuth();
 		try {
 			await signOut(auth);
-			console.log('User logged out successfully');
 		} catch (error) {
 			addToast({ message: '로그아웃에 실패했습니다' });
 		}

--- a/src/app/quiz/[id]/hooks/useModifyQuiz.ts
+++ b/src/app/quiz/[id]/hooks/useModifyQuiz.ts
@@ -1,6 +1,8 @@
+import { useToast } from '@/components/toast';
 import { URL_PATH } from '@/constants/path';
 import { useSessionStorage } from '@/hooks';
 import { http } from '@/lib/api';
+import { CustomError } from '@/lib/error';
 import { generatePath } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
 import useSWRMutation from 'swr/mutation';
@@ -8,8 +10,9 @@ import useSWRMutation from 'swr/mutation';
 const useModifyQuiz = (id: string) => {
 	const router = useRouter();
 	const [quizIds, updateQuizIds] = useSessionStorage<string[]>('quiz-id', []);
+	const addToast = useToast();
 
-	const { trigger } = useSWRMutation<{ quizId: string }>(
+	const { trigger } = useSWRMutation<{ quizId: string }, CustomError>(
 		`/api/quiz/${id}`,
 		http.delete,
 		{
@@ -30,6 +33,9 @@ const useModifyQuiz = (id: string) => {
 						id: quizIds[quizIndex === 0 ? 0 : quizIndex - 1],
 					})
 				);
+			},
+			onError: (error) => {
+				addToast({ message: error.message });
 			},
 		}
 	);

--- a/src/app/quiz/[id]/hooks/useSubmitAnswer.ts
+++ b/src/app/quiz/[id]/hooks/useSubmitAnswer.ts
@@ -1,4 +1,5 @@
 import { http } from '@/lib/api';
+import { CustomError } from '@/lib/error';
 import { MouseEventHandler } from 'react';
 import { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
@@ -6,7 +7,7 @@ import useSWRMutation from 'swr/mutation';
 const useSubmitAnswer = (id: string) => {
 	const { trigger, isMutating, reset } = useSWRMutation<
 		{ result: boolean },
-		Error,
+		CustomError,
 		Key,
 		{ answer: boolean }
 	>(`/api/quiz/${id}`, http.post);

--- a/src/app/quiz/[id]/hooks/useSubmitAnswer.ts
+++ b/src/app/quiz/[id]/hooks/useSubmitAnswer.ts
@@ -1,3 +1,4 @@
+import { useToast } from '@/components/toast';
 import { http } from '@/lib/api';
 import { CustomError } from '@/lib/error';
 import { MouseEventHandler } from 'react';
@@ -5,12 +6,17 @@ import { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
 
 const useSubmitAnswer = (id: string) => {
+	const addToast = useToast();
 	const { trigger, isMutating, reset } = useSWRMutation<
 		{ result: boolean },
 		CustomError,
 		Key,
 		{ answer: boolean }
-	>(`/api/quiz/${id}`, http.post);
+	>(`/api/quiz/${id}`, http.post, {
+		onError: (e) => {
+			addToast({ message: e.message });
+		},
+	});
 
 	const submitAnswerHandler =
 		(answer: boolean): MouseEventHandler<HTMLButtonElement> =>
@@ -19,7 +25,7 @@ const useSubmitAnswer = (id: string) => {
 
 			const { result } = await trigger({ answer });
 
-			console.log(result ? '맞았습니다' : '틀렸습니다');
+			addToast({ message: result ? '맞았습니다' : '틀렸습니다' });
 		};
 
 	return { submitAnswerHandler, isMutating, reset };

--- a/src/app/quiz/[id]/layout.tsx
+++ b/src/app/quiz/[id]/layout.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import styles from './quiz-detail.module.scss';
 import { Header, Navbar, Pagination } from '@/components';
 import { Params } from 'next/dist/shared/lib/router/utils/route-matcher';
 import { usePathname } from 'next/navigation';
 import { useSessionStorage } from '@/hooks';
 import { useModifyQuiz } from './hooks';
+import { Fragment } from 'react';
 
 // NOTE: [id]의 layout과 edit의 layout이 중첩된다. 따라서 Template로 변경했지만, 그것조차 중첩됐다... template는 중첩 안되는것 같던데 왜 된느 건지 모르겠다
+
+// TODO: 디자인상 변경이 필요할 것 같은 느낌이 문득 든다..
 
 const Layout = ({
 	children,
@@ -23,7 +25,7 @@ const Layout = ({
 	const { modifyHandler, deleteHandler } = useModifyQuiz(id);
 
 	return (
-		<>
+		<Fragment>
 			<Header>
 				<Header.BackButton backUrl={-1} />
 				<Header.Title title={isEdit ? '문제 수정하기' : '문제 풀기'} />
@@ -41,9 +43,9 @@ const Layout = ({
 			{!isEdit && (
 				<Pagination currentPosition={id} positions={quizIds} path={`/quiz`} />
 			)}
-			<main className={styles.main}>{children}</main>
+			{children}
 			{!isEdit && <Navbar />}
-		</>
+		</Fragment>
 	);
 };
 

--- a/src/app/quiz/[id]/layout.tsx
+++ b/src/app/quiz/[id]/layout.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Header, Navbar, Pagination } from '@/components';
+import { Header, Pagination } from '@/components';
 import { Params } from 'next/dist/shared/lib/router/utils/route-matcher';
 import { usePathname } from 'next/navigation';
 import { useSessionStorage } from '@/hooks';
 import { useModifyQuiz } from './hooks';
 import { Fragment } from 'react';
+import styles from './quiz-detail.module.scss';
 
 // NOTE: [id]의 layout과 edit의 layout이 중첩된다. 따라서 Template로 변경했지만, 그것조차 중첩됐다... template는 중첩 안되는것 같던데 왜 된느 건지 모르겠다
 
@@ -43,8 +44,7 @@ const Layout = ({
 			{!isEdit && (
 				<Pagination currentPosition={id} positions={quizIds} path={`/quiz`} />
 			)}
-			{children}
-			{!isEdit && <Navbar />}
+			<main className={styles.main}>{children}</main>
 		</Fragment>
 	);
 };

--- a/src/app/quiz/[id]/loading.tsx
+++ b/src/app/quiz/[id]/loading.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { Spinner } from '@/components';
+
+const Loading = () => {
+	return <Spinner />;
+};
+
+export default Loading;

--- a/src/app/quiz/filter/layout.tsx
+++ b/src/app/quiz/filter/layout.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { Header, Navbar } from '@/components';
+import { Header } from '@/components';
 import { Fragment } from 'react';
-import styles from './filter.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -10,8 +9,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 			<Header>
 				<Header.Title title='문제 풀기' />
 			</Header>
-			<main className={styles.main}>{children}</main>
-			<Navbar />
+			{children}
 		</Fragment>
 	);
 };

--- a/src/app/quiz/filter/layout.tsx
+++ b/src/app/quiz/filter/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
+import styles from './filter.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -9,7 +10,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 			<Header>
 				<Header.Title title='문제 풀기' />
 			</Header>
-			{children}
+			<main className={styles.main}>{children}</main>
 		</Fragment>
 	);
 };

--- a/src/app/quiz/filter/page.tsx
+++ b/src/app/quiz/filter/page.tsx
@@ -70,7 +70,6 @@ const QuizFilterPage = () => {
 
 		if (categoryIds.length !== 0) {
 			query += `category-id=${categoryIds.join(',')}&`;
-			console.log(categoryIds.join(','));
 		}
 
 		const favorite =

--- a/src/app/quiz/hooks/useUpdateQuizProperty.ts
+++ b/src/app/quiz/hooks/useUpdateQuizProperty.ts
@@ -1,4 +1,6 @@
+import { useToast } from '@/components/toast';
 import { http } from '@/lib/api';
+import { CustomError } from '@/lib/error';
 import { QuizInfo } from '@/types';
 import { useCallback } from 'react';
 import { Key } from 'swr';
@@ -10,12 +12,18 @@ type UpdateAbleQuizProperty =
 	| Omit<QuizInfo, 'record' | 'categoryId' | 'id'>;
 
 export const useUpdateQuizProperty = (id: string) => {
+	const addToast = useToast();
+
 	const { trigger, isMutating, reset } = useSWRMutation<
 		{ result: boolean },
-		Error,
+		CustomError,
 		Key,
 		UpdateAbleQuizProperty
-	>(`/api/quiz/${id}`, http.patch);
+	>(`/api/quiz/${id}`, http.patch, {
+		onError: (error) => {
+			addToast({ message: error.message });
+		},
+	});
 
 	const updateQuiz = useCallback(
 		async (updateProperty: UpdateAbleQuizProperty) => {

--- a/src/app/quiz/list/layout.tsx
+++ b/src/app/quiz/list/layout.tsx
@@ -2,7 +2,6 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
-import styles from './quiz-list.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -11,7 +10,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 				<Header.BackButton backUrl={-1} />
 				<Header.Title title='문제 풀기' />
 			</Header>
-			<main className={styles.main}>{children}</main>
+			{children}
 		</Fragment>
 	);
 };

--- a/src/app/quiz/list/layout.tsx
+++ b/src/app/quiz/list/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
+import styles from './quiz-list.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -10,7 +11,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 				<Header.BackButton backUrl={-1} />
 				<Header.Title title='문제 풀기' />
 			</Header>
-			{children}
+			<main className={styles.main}>{children}</main>
 		</Fragment>
 	);
 };

--- a/src/app/quiz/register/hooks/useCreateQuiz.ts
+++ b/src/app/quiz/register/hooks/useCreateQuiz.ts
@@ -1,4 +1,6 @@
+import { useToast } from '@/components/toast';
 import { http } from '@/lib/api';
+import { CustomError } from '@/lib/error';
 import { Key } from 'swr';
 import useSWRMutation from 'swr/mutation';
 
@@ -11,12 +13,18 @@ type CreateQuizParams = {
 };
 
 export const useCreateQuiz = () => {
+	const addToast = useToast();
+
 	const { trigger, reset, isMutating } = useSWRMutation<
 		CreateQuizParams & { id: string },
-		Error,
+		CustomError,
 		Key,
 		CreateQuizParams
-	>('/api/quiz', http.post);
+	>('/api/quiz', http.post, {
+		onError: (error) => {
+			addToast({ message: error.message });
+		},
+	});
 
 	const createQuiz = async (params: CreateQuizParams) => {
 		const result = await trigger(params);

--- a/src/app/quiz/register/layout.tsx
+++ b/src/app/quiz/register/layout.tsx
@@ -2,7 +2,6 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
-import styles from './quiz-register.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -11,7 +10,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 				<Header.BackButton backUrl={-1} />
 				<Header.Title title='퀴즈 등록하기' />
 			</Header>
-			<main className={styles.main}>{children}</main>
+			{children}
 		</Fragment>
 	);
 };

--- a/src/app/quiz/register/layout.tsx
+++ b/src/app/quiz/register/layout.tsx
@@ -2,6 +2,7 @@
 
 import { Header } from '@/components';
 import { Fragment } from 'react';
+import styles from './quiz-register.module.scss';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -10,7 +11,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 				<Header.BackButton backUrl={-1} />
 				<Header.Title title='퀴즈 등록하기' />
 			</Header>
-			{children}
+			<main className={styles.main}>{children}</main>
 		</Fragment>
 	);
 };

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import styles from './root.module.scss';
 import { onAuthStateChanged } from '@/lib/firebase';
 import { User } from 'firebase/auth';
 import { useRouter } from 'next/navigation';
@@ -27,19 +26,13 @@ const RootTemplate = ({ children }: { children: React.ReactNode }) => {
 		});
 	}, [router]);
 
-	if (loading) {
-		return <Spinner />;
-	}
-
 	return (
 		<SWRConfig
 			value={{
 				fallback: <Spinner />,
 			}}
 		>
-			<OverlayProvider>
-				<div className={styles.container}>{children}</div>
-			</OverlayProvider>
+			<OverlayProvider>{loading ? <Spinner /> : children}</OverlayProvider>
 		</SWRConfig>
 	);
 };

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -3,7 +3,6 @@ import styles from './navbar.module.scss';
 import { Folder, Plus, Quiz, Profile } from '@/assets';
 import Image from 'next/image';
 import Link from 'next/link';
-import { memo } from 'react';
 
 const Navbar = () => {
 	return (
@@ -36,4 +35,4 @@ const Navbar = () => {
 	);
 };
 
-export default memo(Navbar);
+export default Navbar;

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -7,9 +7,15 @@ export type PaginationProps = {
 	currentPosition: string;
 	positions: string[];
 	path?: string;
+	replace?: boolean;
 };
 
-const Pagination = ({ currentPosition, positions, path }: PaginationProps) => {
+const Pagination = ({
+	currentPosition,
+	positions,
+	path,
+	replace = true,
+}: PaginationProps) => {
 	const { cursor } = useMoveCursor({
 		currentPosition,
 		positions,
@@ -26,12 +32,13 @@ const Pagination = ({ currentPosition, positions, path }: PaginationProps) => {
 						data-path={position}
 						className={styles[className]}
 						href={path ? `${path}/${position}` : position}
+						replace={replace}
 					>
 						{index + 1}
 					</Link>
 				);
 			}),
-		[cursor, path, positions]
+		[cursor, path, positions, replace]
 	);
 
 	return (

--- a/src/components/toast/toast.module.scss
+++ b/src/components/toast/toast.module.scss
@@ -1,6 +1,28 @@
 @import '@/styles/variables.module.scss';
 @import '@/styles/mixins.module.scss';
 
+@keyframes fadeInUp {
+	from {
+		opacity: 0;
+		transform: translateX(-50%) translateY(80px);
+	}
+	to {
+		opacity: 0.9;
+		transform: translateX(-50%) translateY(0);
+	}
+}
+
+@keyframes fadeOutDown {
+	from {
+		opacity: 0.9;
+		transform: translateX(-50%) translateY(0);
+	}
+	to {
+		opacity: 0;
+		transform: translateX(-50%) translateY(80px);
+	}
+}
+
 .toast {
 	position: fixed;
 	left: 50%;
@@ -18,20 +40,17 @@
 	padding: 10px 20px;
 	border-radius: 5px;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	opacity: 0.9;
+	opacity: 0;
 	z-index: 1030;
-	transition: opacity 0.5s ease, transform 0.5s ease;
 	font-size: 1.4rem;
 	line-height: 1.5;
 	font-weight: 400;
 }
 
 .toast.show {
-	opacity: 0.9;
-	transform: translateX(-50%) translateY(0);
+	animation: fadeInUp 0.5s ease forwards;
 }
 
 .toast.hide {
-	opacity: 0;
-	transform: translateX(-50%) translateY(80px);
+	animation: fadeOutDown 0.5s ease forwards;
 }

--- a/src/lib/api/_http.ts
+++ b/src/lib/api/_http.ts
@@ -35,8 +35,6 @@ export const http = {
 			body: JSON.stringify(params),
 		});
 
-		console.log(response, 'response?');
-
 		const data = (await response.json()) as ResponseResult<T>;
 
 		if (data.message === 'FAILURE') {

--- a/src/lib/api/_http.ts
+++ b/src/lib/api/_http.ts
@@ -1,5 +1,6 @@
 import { BASE_URL } from '@/constants/path';
 import type { FailureResponse, SuccessResponse } from '.';
+import { CustomError } from '../error';
 
 type ResponseResult<T> = SuccessResponse<T> | FailureResponse;
 
@@ -17,7 +18,7 @@ export const http = {
 		const data = (await response.json()) as ResponseResult<T>;
 
 		if (data.message === 'FAILURE') {
-			throw new Error(`data.errors`);
+			throw new CustomError(data.errors);
 		}
 
 		return data.data;
@@ -34,10 +35,12 @@ export const http = {
 			body: JSON.stringify(params),
 		});
 
+		console.log(response, 'response?');
+
 		const data = (await response.json()) as ResponseResult<T>;
 
 		if (data.message === 'FAILURE') {
-			throw new Error(`data.errors`);
+			throw new CustomError(data.errors);
 		}
 
 		return data.data;
@@ -57,7 +60,7 @@ export const http = {
 		const data = (await response.json()) as ResponseResult<T>;
 
 		if (data.message === 'FAILURE') {
-			throw new Error(`data.errors`);
+			throw new CustomError(data.errors);
 		}
 
 		return data.data;
@@ -76,7 +79,7 @@ export const http = {
 		const data = (await response.json()) as ResponseResult<T>;
 
 		if (data.message === 'FAILURE') {
-			throw new Error(`data.errors`);
+			throw new CustomError(data.errors);
 		}
 
 		return data.data;

--- a/src/lib/error/CustomError.ts
+++ b/src/lib/error/CustomError.ts
@@ -1,0 +1,14 @@
+import { APIError } from '.';
+
+export class CustomError extends Error {
+	message: string;
+	code: number | null = null;
+
+	constructor(params: APIError | Pick<Error, 'message'>) {
+		super();
+		this.message = params.message;
+		if ('code' in params) {
+			this.code = params.code;
+		}
+	}
+}

--- a/src/lib/error/CustomError.ts
+++ b/src/lib/error/CustomError.ts
@@ -1,8 +1,9 @@
 import { APIError } from '.';
+import { HTTP_STATUS_CODE } from '../request-wrapper';
 
 export class CustomError extends Error {
 	message: string;
-	code: number | null = null;
+	code: (typeof HTTP_STATUS_CODE)[keyof typeof HTTP_STATUS_CODE] | null = null;
 
 	constructor(params: APIError | Pick<Error, 'message'>) {
 		super();

--- a/src/lib/error/error.type.ts
+++ b/src/lib/error/error.type.ts
@@ -1,0 +1,4 @@
+export type APIError = {
+	code: number;
+	message: string;
+};

--- a/src/lib/error/error.type.ts
+++ b/src/lib/error/error.type.ts
@@ -1,4 +1,6 @@
+import type { HTTP_STATUS_CODE } from '../request-wrapper';
+
 export type APIError = {
-	code: number;
+	code: (typeof HTTP_STATUS_CODE)[keyof typeof HTTP_STATUS_CODE];
 	message: string;
 };

--- a/src/lib/error/index.ts
+++ b/src/lib/error/index.ts
@@ -1,0 +1,2 @@
+export * from './CustomError';
+export * from './error.type';

--- a/src/lib/firebase/auth.ts
+++ b/src/lib/firebase/auth.ts
@@ -20,6 +20,7 @@ export const signInWithGoogle = async (): Promise<UserCredential> => {
 
 		return result;
 	} catch (error) {
+		console.log(error, ' ERROR');
 		throw new Error('로그인시 문제가 발생했습니다.');
 	}
 };

--- a/src/lib/firebase/fire-store.ts
+++ b/src/lib/firebase/fire-store.ts
@@ -48,7 +48,7 @@ export const createCollection = async <T, D extends DocumentData>({
 		const docSnap = await getDoc(docRef);
 
 		if (!docSnap.exists()) {
-			throw new Error('존재하지 않는 경로입니다.');
+			throw new Error('존재하지 않는 경로입니다');
 		}
 
 		const newCollectionRef = collection(docRef, key).withConverter(converter);
@@ -71,7 +71,7 @@ export const createCollectionDocument = async ({
 
 		return docRef;
 	} catch (e) {
-		throw new Error('새 문서를 생성하는 데 실패했습니다.');
+		throw new Error('새 문서를 생성하는 데 실패했습니다');
 	}
 };
 
@@ -83,10 +83,9 @@ export const updateDocumentData = async ({
 }: WithMergeOption): Promise<void> => {
 	try {
 		const documentRef = doc(db, path);
-
 		await setDoc(documentRef, data, { merge });
 	} catch (e) {
-		throw new Error('문서를 업데이트하는데 실패했습니다.');
+		throw new Error('문서를 업데이트하는데 실패했습니다');
 	}
 };
 
@@ -95,7 +94,11 @@ export const getDocumentSnapshot = async <T, D extends DocumentData>(
 	path: string,
 	converter: FirestoreDataConverter<T, D>
 ): Promise<DocumentSnapshot<T, DocumentData>> => {
-	return await getDoc(doc(db, `${path}`).withConverter(converter));
+	try {
+		return await getDoc(doc(db, `${path}`).withConverter(converter));
+	} catch (e) {
+		throw new Error('문서를 불러오는데 실패했습니다');
+	}
 };
 
 // NOTE: queryConstraints(쿼리 제약)에 해당하는 여러 문서들을 반환하는 메서드
@@ -104,29 +107,41 @@ export const getFilteredQuerySnapShot = async <T, D extends DocumentData>(
 	converter: FirestoreDataConverter<T, D>,
 	filter: QueryFilterConstraint[] = []
 ): Promise<QuerySnapshot<T, D>> => {
-	const docRef = collection(db, `${path}`);
+	try {
+		const docRef = collection(db, `${path}`);
 
-	const currentQuery = query(docRef, and(...filter)).withConverter(converter);
+		const currentQuery = query(docRef, and(...filter)).withConverter(converter);
 
-	const querySnapshot = await getDocs(currentQuery);
+		const querySnapshot = await getDocs(currentQuery);
 
-	return querySnapshot;
+		return querySnapshot;
+	} catch (e) {
+		throw new Error('문서를 불러오는데 실패했습니다');
+	}
 };
 
 export const updateDocument = async <T extends { [x: string]: any }>(
 	path: string,
 	data: T
 ) => {
-	const documentRef = doc(db, path);
+	try {
+		const documentRef = doc(db, path);
 
-	await updateDoc(documentRef, {
-		...data,
-	});
+		await updateDoc(documentRef, {
+			...data,
+		});
+	} catch (e) {
+		throw new Error('문서를 업데이트하는데 실패했습니다');
+	}
 };
 
 // NOTE: Document를 제거하는 메서드
 export const deleteDocument = async (path: string) => {
-	const document = doc(db, `${path}`);
+	try {
+		const document = doc(db, `${path}`);
 
-	await deleteDoc(document);
+		await deleteDoc(document);
+	} catch (e) {
+		throw new Error('문서를 삭제하는데 실패했습니다');
+	}
 };

--- a/src/lib/firebase/fire-store.ts
+++ b/src/lib/firebase/fire-store.ts
@@ -17,7 +17,7 @@ import {
 	FirestoreDataConverter,
 	updateDoc,
 } from 'firebase/firestore';
-import { app } from '.';
+import { firestore } from '.';
 
 type MutateDocumentPathParams = {
 	path: string;
@@ -27,8 +27,6 @@ type MutateDocumentPathParams = {
 type WithMergeOption = MutateDocumentPathParams & {
 	merge?: boolean;
 };
-
-const db = getFirestore(app);
 
 // NOTE: 중첩된 문서 경로에 컬렉션을 추가하는 메서드. data 값을 추가한다면, 생성과 동시에 새로운 값을 추가할 수 있다.
 export const createCollection = async <T, D extends DocumentData>({
@@ -43,7 +41,7 @@ export const createCollection = async <T, D extends DocumentData>({
 	converter: FirestoreDataConverter<T, D>;
 }): Promise<DocumentReference<T, D>> => {
 	try {
-		const docRef = doc(db, path);
+		const docRef = doc(firestore, path);
 
 		const docSnap = await getDoc(docRef);
 
@@ -67,7 +65,7 @@ export const createCollectionDocument = async ({
 	DocumentReference<DocumentData, DocumentData>
 > => {
 	try {
-		const docRef = await addDoc(collection(db, `${path}`), data);
+		const docRef = await addDoc(collection(firestore, `${path}`), data);
 
 		return docRef;
 	} catch (e) {
@@ -82,7 +80,7 @@ export const updateDocumentData = async ({
 	data,
 }: WithMergeOption): Promise<void> => {
 	try {
-		const documentRef = doc(db, path);
+		const documentRef = doc(firestore, path);
 		await setDoc(documentRef, data, { merge });
 	} catch (e) {
 		throw new Error('문서를 업데이트하는데 실패했습니다');
@@ -95,7 +93,7 @@ export const getDocumentSnapshot = async <T, D extends DocumentData>(
 	converter: FirestoreDataConverter<T, D>
 ): Promise<DocumentSnapshot<T, DocumentData>> => {
 	try {
-		return await getDoc(doc(db, `${path}`).withConverter(converter));
+		return await getDoc(doc(firestore, `${path}`).withConverter(converter));
 	} catch (e) {
 		throw new Error('문서를 불러오는데 실패했습니다');
 	}
@@ -108,7 +106,7 @@ export const getFilteredQuerySnapShot = async <T, D extends DocumentData>(
 	filter: QueryFilterConstraint[] = []
 ): Promise<QuerySnapshot<T, D>> => {
 	try {
-		const docRef = collection(db, `${path}`);
+		const docRef = collection(firestore, `${path}`);
 
 		const currentQuery = query(docRef, and(...filter)).withConverter(converter);
 
@@ -125,7 +123,7 @@ export const updateDocument = async <T extends { [x: string]: any }>(
 	data: T
 ) => {
 	try {
-		const documentRef = doc(db, path);
+		const documentRef = doc(firestore, path);
 
 		await updateDoc(documentRef, {
 			...data,
@@ -138,7 +136,7 @@ export const updateDocument = async <T extends { [x: string]: any }>(
 // NOTE: Document를 제거하는 메서드
 export const deleteDocument = async (path: string) => {
 	try {
-		const document = doc(db, `${path}`);
+		const document = doc(firestore, `${path}`);
 
 		await deleteDoc(document);
 	} catch (e) {

--- a/src/lib/firebase/fire-store.ts
+++ b/src/lib/firebase/fire-store.ts
@@ -28,6 +28,8 @@ type WithMergeOption = MutateDocumentPathParams & {
 	merge?: boolean;
 };
 
+// TODO: firebase-admin sdk로 유저 관리하기 (root collection 삭제 가능하도록)
+
 // NOTE: 중첩된 문서 경로에 컬렉션을 추가하는 메서드. data 값을 추가한다면, 생성과 동시에 새로운 값을 추가할 수 있다.
 export const createCollection = async <T, D extends DocumentData>({
 	path,
@@ -140,6 +142,7 @@ export const deleteDocument = async (path: string) => {
 
 		await deleteDoc(document);
 	} catch (e) {
+		console.log(e);
 		throw new Error('문서를 삭제하는데 실패했습니다');
 	}
 };

--- a/src/lib/firebase/initialize-firebase.ts
+++ b/src/lib/firebase/initialize-firebase.ts
@@ -1,12 +1,8 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
-// Import the functions you need from the SDKs you need
-
-// https://firebase.google.com/docs/web/setup#available-libraries
-
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+// Firebase 구성 설정
 const firebaseConfig = {
 	apiKey: process.env.NEXT_PUBLIC_FB_API_KEY,
 	authDomain: process.env.NEXT_PUBLIC_FB_AUTH_DOMAIN,
@@ -17,5 +13,10 @@ const firebaseConfig = {
 	measurementId: process.env.NEXT_PUBLIC_FB_MEASUREMENT_ID,
 };
 
-export const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
+const app = initializeApp(firebaseConfig);
+
+const auth = getAuth(app);
+
+const firestore = getFirestore(app);
+
+export { app, auth, firestore };

--- a/src/lib/request-wrapper/request-wrapper.ts
+++ b/src/lib/request-wrapper/request-wrapper.ts
@@ -1,4 +1,9 @@
-import { HTTP_METHOD, HTTP_STATUS_CODE, RESPONSE_NOT_FOUND } from './constants';
+import {
+	HTTP_METHOD,
+	HTTP_STATUS_CODE,
+	RESPONSE_MESSAGE,
+	RESPONSE_NOT_FOUND,
+} from './constants';
 import type {
 	NextResponseWithResponseTypeParams,
 	RequestWrapper,
@@ -29,7 +34,32 @@ export const requestWrapper: RequestWrapper =
 		}
 
 		if (methodWhiteList && methodWhiteList.includes(method)) {
-			return handler(req);
+			try {
+				const result = await handler(req);
+
+				return result;
+			} catch (e) {
+				let message = '알 수 없는 에러가 발생했습니다.';
+
+				if (e instanceof Error) {
+					message = e.message;
+				}
+
+				return nextResponseWithResponseType({
+					body: {
+						message: RESPONSE_MESSAGE.FAILURE,
+						code: null,
+						data: null,
+						errors: {
+							code: HTTP_STATUS_CODE.NOT_FOUND,
+							message,
+						},
+					},
+					options: {
+						status: HTTP_STATUS_CODE.NOT_FOUND,
+					},
+				});
+			}
 		}
 
 		return new NextResponse(JSON.stringify(RESPONSE_NOT_FOUND), {

--- a/src/lib/request-wrapper/types.ts
+++ b/src/lib/request-wrapper/types.ts
@@ -1,3 +1,4 @@
+import { APIError } from '../error';
 import { HTTP_STATUS_CODE } from './constants';
 import { NextResponse, NextRequest as BaseNextRequest } from 'next/server';
 
@@ -17,10 +18,7 @@ export type FailureType = {
 	message: 'FAILURE';
 	code: null;
 	data: null;
-	errors: {
-		code: number;
-		message: string;
-	};
+	errors: APIError;
 };
 
 export type ResponseType<D> = SuccessType<D> | FailureType;


### PR DESCRIPTION
### DONE

- [x] 에러 적용 방식을 통일 (Custom Error 생성)
- [x]  fire-base 로그인 에러 해결
- [x] 쿠키 유효시간 설정
- [x] `pagination` replace 옵션 추가
- [x]  로그아웃 기능 구현
---

### TODO
- [ ] 사용자 삭제 기능 구현하기 (firebase-admin SDK 추가)
- [ ] 에러 페이지 구현하기

--- 

### Firebase 에러
1. coop, corp 문제
    1. next.config 파일에 헤더 관련 설정 추가
    2. 하지만, third-party 라이브러리에서 pop-up이 허용되지 않아서 닫히는 문제 발생
    3. config 파일 수정으로 해결
2. 로그인 성공 후 redirect가 되지 않는 문제
    1. 이것때문에 이유를 골머리좀 썩히다가 middleware에서 다음 페이지로 넘어가지 않는 걸 발견
    2. `api` 처리를 할 때 쿠키 값이 스토리지에 저장되지 않는 문제로 인해, 인증 값이 쿠키에 저장되지 않았고, 그것 때문에 Middleware에서 redirect하는 문제.
    3. expires → maxAge로 쿠키 설정을 변경하고 해결